### PR TITLE
Add ability to sort listing table columns and reduce display area

### DIFF
--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -22,11 +22,15 @@
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <link rel="stylesheet" href="css/normalize.css">
   <link rel="stylesheet" href="css/skeleton.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.11.1/bootstrap-table.min.css">
 
 
   <!-- Favicon
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <link rel="icon" type="image/png" href="images/favicon.png">
+
+  <script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.11.1/bootstrap-table.min.js" async></script>
+  
 </head>
 <body>
 
@@ -47,28 +51,31 @@
     </div>
     <div class="container">
       <%= button_to "Run Scraper", scrapers_path %>
-  <table class="table">
-    <tr id="headers">
-      <th class="heading-label">heading</th>
-      <th class="date-time-label">listed at</th>
-      <th class="address-label">address</th>
-      <th class="latitude-label">latitude</th>
-      <th class="longitude-label">longitude</th>
-      <th class="description-label">description</th>
-      <th class="descriminatory-label">discriminatory</th>
-    </tr>
-
-    <% @listings.each do |listing| %>
-      <tr class="housing-column">
-        <td class="heading-item"><%= link_to listing.heading, listing_path(listing) %></td>
-        <td class="date-time-item"><%= listing.listed_at %></td>
-        <td class="address-item"><%= listing.address %></td>
-        <td class="latitude-item"><%= listing.latitude %></td>
-        <td class="longitude-item"><%= listing.longitude %></td>
-        <td class="description-item"><%= listing.description %></td>
-        <td class="descriminatory-item"><%= listing.discriminatory %></td>
+  <table class="table" data-toggle="table" data-height="400">
+    <thead>
+      <tr>
+        <th data-sortable="true" class="heading-label">heading</th>
+        <th data-sortable="true" class="date-time-label">listed at</th>
+        <th data-sortable="true" class="address-label">address</th>
+        <th data-sortable="true" class="latitude-label">latitude</th>
+        <th data-sortable="true" class="longitude-label">longitude</th>
+        <th data-sortable="true" class="description-label">description</th>
+        <th data-sortable="true" class="descriminatory-label">discriminatory</th>
       </tr>
-    <% end %>
+    </thead>
+    <tbody>
+      <% @listings.each do |listing| %>
+        <tr class="housing-column">
+          <td class="heading-item"><%= link_to listing.heading, listing_path(listing) %></td>
+          <td class="date-time-item"><%= listing.listed_at %></td>
+          <td class="address-item"><%= listing.address %></td>
+          <td class="latitude-item"><%= listing.latitude %></td>
+          <td class="longitude-item"><%= listing.longitude %></td>
+          <td class="description-item"><%= listing.description %></td>
+          <td class="descriminatory-item"><%= listing.discriminatory %></td>
+        </tr>
+      <% end %>
+    </tbody>
   </table>
   <%= will_paginate @listings %>
 


### PR DESCRIPTION
Basic table features for https://github.com/codeforboston/legalhousing/issues/82

Adds column sorting and reduces the size of the table, keeping the column headers always visible.

![image](https://user-images.githubusercontent.com/4166486/26858912-4061d84a-4b02-11e7-86a8-8f6bf5937487.png)
