### PR TITLE
implement PhraseListing for 'illegal' phrases found in listings; added method for phrase counts

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -5,6 +5,8 @@ class Listing < ApplicationRecord
   def illegal?
     Phrase.all.each do |phrase|
       if self.description.match(/#{phrase.content}/i)
+				PhraseListing.create(listing_id: self.id, phrase_id: phrase.id)				
+				self.save
         return true
       end
     end
@@ -21,6 +23,12 @@ class Listing < ApplicationRecord
     end
   end
 
+	def self.set_discriminatory
+		Listing.all.each do |listing|
+			listing.illegal?
+		end
+	end
+	
   def self.discriminatory
     Listing.all.select {|listing| listing.discriminatory == true}
   end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -5,7 +5,7 @@ class Listing < ApplicationRecord
   def illegal?
     Phrase.all.each do |phrase|
       if self.description.match(/#{phrase.content}/i)
-				PhraseListing.create(listing_id: self.id, phrase_id: phrase.id)				
+				PhraseListing.find_or_create_by(listing_id: self.id, phrase_id: phrase.id)				
 				self.save
         return true
       end

--- a/app/models/phrase.rb
+++ b/app/models/phrase.rb
@@ -17,4 +17,12 @@ class Phrase < ApplicationRecord
     Phrase.destroy_all
 		ActiveRecord::Base.connection.reset_pk_sequence!('phrases')
   end
+
+	def self.phrase_counts
+		counts = {}
+		PhraseListing.all.each do |phrase_listing|
+			counts[phrase_listing.phrase.content] = PhraseListing.all.where(phrase_id: phrase_listing.phrase_id).count
+		end
+		counts
+	end
 end

--- a/spec/models/phrase_spec.rb
+++ b/spec/models/phrase_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe Phrase, type: :model do
   end
 
   it 'imports the app/assets/Words.txt file' do 
+		wordsfile = File.join Rails.root, "./assets/Words.txt"
+    wordscount = CSV.read(wordsfile)[0].count
     Phrase.reset_phrases
     Phrase.import_words
-
-    expect(Phrase.count).to eq(40)
+    expect(Phrase.count).to eq(wordscount)
   end
 end


### PR DESCRIPTION
1. Updated method: 'listing.illegal?' method to implement PhraseListing join table entry; by adding a unique entry for each instance of a phrase appearing in a listing description. 
2. Added method: Listing.set_discriminatory, to provide a method to run all Listings through 'listing.illegal?' method.
3. Added method: Phrase.phrase_counts, which returns hash of key/value pairs (phrases and counts) derived from PhraseListing table.