### PR TITLE
Added Listing.date range method

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -5,6 +5,8 @@ class Listing < ApplicationRecord
   def illegal?
     Phrase.all.each do |phrase|
       if self.description.match(/#{phrase.content}/i)
+				PhraseListing.create(listing_id: self.id, phrase_id: phrase.id)				
+				self.save
         return true
       end
     end
@@ -21,6 +23,12 @@ class Listing < ApplicationRecord
     end
   end
 
+	def self.set_discriminatory
+		Listing.all.each do |listing|
+			listing.illegal?
+		end
+	end
+	
   def self.discriminatory
     Listing.all.select {|listing| listing.discriminatory == true}
   end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -5,7 +5,7 @@ class Listing < ApplicationRecord
   def illegal?
     Phrase.all.each do |phrase|
       if self.description.match(/#{phrase.content}/i)
-				PhraseListing.create(listing_id: self.id, phrase_id: phrase.id)				
+				PhraseListing.find_or_create_by(listing_id: self.id, phrase_id: phrase.id)				
 				self.save
         return true
       end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -40,4 +40,21 @@ class Listing < ApplicationRecord
 	def self.num_discriminatory
 		Listing.discriminatory.count
 	end
+
+# default values for dates, if none are passed in
+# format for date arguments: 'yyyy-mm-dd', or any portion of a date starting with 'yyyy'
+	def self.date_range(start_date='2015', end_date='2020')
+		@listings_in_range = []
+		PhraseListing.all.each do |phrase_listing|
+			listed = phrase_listing.listing.listed_at.year.to_s + '-' + phrase_listing.listing.listed_at.month.to_s + '-' + phrase_listing.listing.listed_at.day.to_s
+			if listed >= start_date && listed <= end_date
+				@listings_in_range.push(phrase_listing.listing)
+			end
+		end
+		if @listings_in_range.count > 0 
+			@listings_in_range
+		else 
+			return 'No listings found in date range specified'
+		end
+	end
 end

--- a/app/models/phrase.rb
+++ b/app/models/phrase.rb
@@ -17,4 +17,12 @@ class Phrase < ApplicationRecord
     Phrase.destroy_all
 		ActiveRecord::Base.connection.reset_pk_sequence!('phrases')
   end
+
+	def self.phrase_counts
+		counts = {}
+		PhraseListing.all.each do |phrase_listing|
+			counts[phrase_listing.phrase.content] = PhraseListing.all.where(phrase_id: phrase_listing.phrase_id).count
+		end
+		counts
+	end
 end

--- a/spec/models/phrase_spec.rb
+++ b/spec/models/phrase_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe Phrase, type: :model do
   end
 
   it 'imports the app/assets/Words.txt file' do 
+		wordsfile = File.join Rails.root, "./assets/Words.txt"
+    wordscount = CSV.read(wordsfile)[0].count
     Phrase.reset_phrases
     Phrase.import_words
-
-    expect(Phrase.count).to eq(40)
+    expect(Phrase.count).to eq(wordscount)
   end
 end


### PR DESCRIPTION
Listing.date_range, polls the PhraseListing table, for listings with 'listed_at' date within dates passed in.
Defaults are currently hard coded to include the years 2015 to 2018, if no dates are passed in.
Returns an array of listings:  @listings_in_range
or
Returns "No listings found....msg"
