### PR TITLE
Feature/add phrase count to stats

### DIFF
--- a/app/assets/javascripts/stats.js
+++ b/app/assets/javascripts/stats.js
@@ -23,8 +23,22 @@ function getStatsApi(dateRange)
      }
    });
  }
+  
 function displayStats(stats) {
   console.log(stats);
   document.getElementById("num_list").innerHTML = stats.data.num_listings;
   document.getElementById("num_disc").innerHTML = stats.data.num_discriminatory;
+  var phrase_count_list = document.getElementById("phrase_count_list");
+  
+  // Clear out any old results in the phrase count display
+  while (phrase_count_list.firstChild) {
+    phrase_count_list.removeChild(phrase_count_list.firstChild);
+  }
+
+  for (key in stats.data.discriminatory_phrase_count) {
+    phrase = key + ": " + stats.data.discriminatory_phrase_count[key]
+    var entry = document.createElement('li');
+    entry.appendChild(document.createTextNode(phrase));
+    phrase_count_list.appendChild(entry);
+  }
 }

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -37,7 +37,7 @@ class StatsController < ApplicationController
     end
   end
 
-  #private
+  private
 
   def compute_stats(start_date_input, end_date_input)
     # Listing.date_range requires strings. Convert here if a Date object was passed in

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -2,16 +2,6 @@
 class StatsController < ApplicationController
   # @@cashedStats = {}
 
-  def compute_stats
-    @num_listings = Listing.num_listings
-    @num_discriminatory = Listing.num_discriminatory
-    @stats = {
-      num_listings: @num_listings,
-      num_discriminatory: @num_discriminatory
-    }
-    @stats
-  end
-
   def index; end
 
   def get_stats
@@ -28,7 +18,7 @@ class StatsController < ApplicationController
 
     start_date = '2015-01-01' if token == 'all'
 
-    listings = Listing.date_range( start_date.to_s, end_date.to_s )
+    
     stats = ''
 
     # check if token exists in hash
@@ -37,7 +27,7 @@ class StatsController < ApplicationController
       # stats = @@cashedStats[token]
     # else, compute the value., add it to hash, return it
     # else
-      stats = compute_stats
+      stats = compute_stats(start_date, end_date)
       # @@cachedStats[token] = stats
     # end
 
@@ -47,5 +37,29 @@ class StatsController < ApplicationController
     end
   end
 
+  #private
+
+  def compute_stats(start_date_input, end_date_input)
+    # Listing.date_range requires strings. Convert here if a Date object was passed in
+    start_date = start_date_input.is_a?(Date) ? start_date_input.to_s : start_date_input
+    end_date = end_date_input.is_a?(Date) ? end_date_input.to_s : end_date_input
+
+    @date_filtered_listings = Listing.date_range(start_date, end_date)
+    @num_listings = @date_filtered_listings.length
+    @num_discriminatory = @date_filtered_listings.count{ |listing| listing.illegal? }
+    
+    @discriminatory_phrase_count = {}
+    Phrase.all.each do |phrase|
+      @num_found = @date_filtered_listings.count { |listing| listing.check_phrase(phrase.content) }
+      @discriminatory_phrase_count[phrase.content] = @num_found
+    end
+    
+    @stats = {
+      num_listings: @num_listings,
+      num_discriminatory: @num_discriminatory,
+      discriminatory_phrase_count: @discriminatory_phrase_count
+    }
+    @stats
+  end
 
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -43,14 +43,14 @@ class Listing < ApplicationRecord
 
 # default values for dates, if none are passed in
 # format for date arguments: 'yyyy-mm-dd', or any portion of a date starting with 'yyyy'
-	def self.date_range(start_date_str='2000-2-1', end_date_str='')
+  def self.date_range(start_date_str='2000-2-1', end_date_str='')
     start_date = Date.parse(start_date_str)
     end_date = Date.parse(end_date_str)
 		@listings_in_range = []
-		PhraseListing.all.each do |phrase_listing|
-			listed = phrase_listing.listing.listed_at
+		Listing.all.each do |phrase_listing|
+			listed = phrase_listing.listed_at
 			if listed >= start_date && listed <= end_date
-				@listings_in_range.push(phrase_listing.listing)
+				@listings_in_range.push(phrase_listing)
 			end
 		end
 		@listings_in_range

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -15,4 +15,7 @@
 <div class="displayStats">
   <label>Total number of listings: </label><div id="num_list"></div>
   <label>Number of discriminatory listings: </label><div id="num_disc"></div>
+  <label>Phrases count: </label>
+  <ul id="phrase_count_list"></ul>
+
 </div>


### PR DESCRIPTION
Adds counts for each discriminatory phrase to the stats object returned by `StatsController.get_stats`. Displays the returned counts as an unordered list in `stats/index.html.erb`.

I changed `date_range` in `app/models/listing.rb` to find `Listing` entries instead of `PhraseListing` entries for two reasons:
1. It didn't make sense that querrying the `listing` model would return only `PhraseListing` entries. If we want a function to return `PhraseListing` entries, that should live in the `PhraseListing` model file
2. This function was causing a lot of database queries which was very slow even with the few listings we have in our seed data. I suspect that this is a combination of `PhraseListing` being a join table and the way the function is written. Someone with more rails experience may have a better explanation for this.

