### PR TITLE
When a listing is saved, check if discriminatory

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -1,6 +1,8 @@
 class Listing < ApplicationRecord
 	has_many :phrase_listings
-	has_many :phrases, through: :phrase_listings
+  has_many :phrases, through: :phrase_listings
+  
+  before_save :check_discriminatory_and_set_flag
 
   def illegal?
     flag = false
@@ -56,4 +58,13 @@ class Listing < ApplicationRecord
 		@listings_in_range
 	end
 
+  private
+
+  def check_discriminatory_and_set_flag
+    if illegal?
+      self.discriminatory = true
+    else
+      self.discriminatory = false
+    end
+  end
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -61,10 +61,6 @@ class Listing < ApplicationRecord
   private
 
   def check_discriminatory_and_set_flag
-    if illegal?
-      self.discriminatory = true
-    else
-      self.discriminatory = false
-    end
+      self.discriminatory = illegal?
   end
 end


### PR DESCRIPTION
Addresses issue #128 

Every time a listing model is saved, we will check if the record is "illegal" and updates the discriminatory flag in the listing model. The `illegal?` method currently will create a PhraseListing entry when it finds the listing is considered illegal. We probably want to look into a way that makes sure to remove this entry from the PhraseLisiting table if the offending phrase is removed from the Listing entry
