### PR TITLE
Feature/128 set discriminatory flag on save

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -76,10 +76,11 @@ class Listing < ApplicationRecord
   end
 
   def add_phrase_listing_entries
-    found_phrases = find_discriminatory_phrases
-    for phrase in found_phrases do
-      puts "Creating PhraseListing from phrase #{phrase}"
-      PhraseListing.create(listing_id: self.id, phrase_id: phrase.id)
+    if self.discriminatory
+      found_phrases = find_discriminatory_phrases
+      for phrase in found_phrases do
+        PhraseListing.create(listing_id: self.id, phrase_id: phrase.id)
+      end
     end
   end
 

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -3,17 +3,12 @@ class Listing < ApplicationRecord
   has_many :phrases, through: :phrase_listings
   
   before_save :check_discriminatory_and_set_flag
+  after_save :add_phrase_listing_entries
 
   def illegal?
-    flag = false
-    Phrase.all.each do |phrase|
-      if self.check_phrase(phrase.content)
-        PhraseListing.create(listing_id: self.id, phrase_id: phrase.id)
-        flag = true
-      end
-    end
-  return flag
+    return self.discriminatory
   end
+
 
   def check_phrase(phrase)
     regex = phrase.strip.gsub(' ','\s+')
@@ -60,7 +55,32 @@ class Listing < ApplicationRecord
 
   private
 
-  def check_discriminatory_and_set_flag
-      self.discriminatory = illegal?
+  # Returns an array of discriminory phrases found in the listing
+  def find_discriminatory_phrases
+    found_phrases = []
+    Phrase.all.each do |phrase|
+      if self.check_phrase(phrase.content)
+        found_phrases.append(phrase)
+      end
+    end
+    return found_phrases
   end
+
+  def check_discriminatory_and_set_flag
+    found_phrases = find_discriminatory_phrases
+    if found_phrases.empty?
+      self.discriminatory = false
+    else
+      self.discriminatory = true
+    end
+  end
+
+  def add_phrase_listing_entries
+    found_phrases = find_discriminatory_phrases
+    for phrase in found_phrases do
+      puts "Creating PhraseListing from phrase #{phrase}"
+      PhraseListing.create(listing_id: self.id, phrase_id: phrase.id)
+    end
+  end
+
 end

--- a/app/models/phrase_listing.rb
+++ b/app/models/phrase_listing.rb
@@ -1,4 +1,5 @@
 class PhraseListing < ApplicationRecord
 	belongs_to :phrase
 	belongs_to :listing
+	validates_uniqueness_of :phrase, scope: :listing
 end


### PR DESCRIPTION
Continuation of feature #128 . See first PR #134 .

This cleans up the Listing controller and fixes some issues in the previous PR:

- `Ilegal?` now just returns the discriminatory flag
- On `before_save` we detect if there is any discriminatory phrases and update the flag. We need to do this before we save since this is a column in the database. Doing this `after_save` would not update this in the table.
- On `after_save` we create a `PhraseListing` table entry if there is a discriminatory listing. This is done `after_save` since a new listing needs a `id` to be inserted into the join table
- Adds a uniqueness requirement to the `PhraseListing` table.