### PR TITLE
Fix Bar Chart Stats and PieChart ToolTip

### DIFF
--- a/app/assets/javascripts/stats.js
+++ b/app/assets/javascripts/stats.js
@@ -2,8 +2,6 @@
 // All this logic will automatically be available in application.js.
 
 
-
-
 var getStats = function(){
   var e = document.getElementById('date_range');
   var dateRange = e.options[e.selectedIndex].value;
@@ -15,9 +13,10 @@ var getStats = function(){
 
 function getStatsApi(dateRange)
  {
+   console.log(dateRange)
    $.ajax({
      type: 'POST',
-     url: '/tools/stats.json',
+     url: '/tools/stats',
      data: {token: dateRange},
      async: false,
      dataType: 'json',
@@ -33,7 +32,7 @@ function getStatsApi(dateRange)
  }
 
 function displayStats(stats) {
-  console.log(stats);
+
   document.getElementById("num_list").innerHTML = stats.data.num_listings;
   document.getElementById("num_disc").innerHTML = stats.data.num_discriminatory;
   var phrase_count_list = document.getElementById("phrase_count_list");
@@ -53,6 +52,7 @@ function displayStats(stats) {
 
 function drawPieChart(stats){
   $(function () {
+
     const totalCount = stats.data.num_listings;
     const discriminatoryCount = stats.data.num_discriminatory;
     const nonDiscriminatoryCount = totalCount - discriminatoryCount;
@@ -66,6 +66,9 @@ function drawPieChart(stats){
       },
       title: {
         text: 'Statistics'
+      },
+      tooltip: {
+        pointFormat: "Value: {point.y:.0f}"
       },
       series: [{
         data: [

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -31,7 +31,6 @@ class StatsController < ApplicationController
     if(bNeedsCacheRefresh)
 
       numMonths = 0
-
       # Convert the token into a number of months
       case token
       when '1m'
@@ -94,17 +93,17 @@ class StatsController < ApplicationController
     @num_listings = @date_filtered_listings.length
     @num_discriminatory = @date_filtered_listings.count{ |listing| listing.illegal? }
 
-    @discriminatory_phrase_count = {}
-    Phrase.all.each do |phrase|
-      @num_found = @date_filtered_listings.count { |listing| listing.check_phrase(phrase.content) }
-      @discriminatory_phrase_count[phrase.content] = @num_found
-    end
+    @discriminatory_phrase_count = Phrase.joins(:listings)
+                  .where('listings.listed_at >= :start_date AND listings.listed_at <= :end_date ',
+                        { start_date: start_date, end_date: end_date})
+                  .group(:content).count
 
     @stats = {
       num_listings: @num_listings,
       num_discriminatory: @num_discriminatory,
       discriminatory_phrase_count: @discriminatory_phrase_count
     }
+    puts @stats
     @stats
   end
 end

--- a/lib/tasks/classify_listings.rake
+++ b/lib/tasks/classify_listings.rake
@@ -39,4 +39,37 @@ namespace :classify_listings do
       puts "#{@percent_array}"
   end
 
+  desc 'Check Discriminatory Listing Statistics'
+  task check_stats: :environment do
+
+    stats = Phrase.joins(:listings)
+                  .where('listings.listed_at >= :start_date AND listings.listed_at <= :end_date ',
+                        { start_date: '2010-01-01', end_date: '2020-01-01'})
+                  .group(:content).count
+    puts "Toal Listings: #{Listing.all.count}"
+    puts "Total Discriminatory: #{stats.values.reduce(:+)}"
+    puts "Discriminatory Breakdown: #{stats}"
+
+
+    # puts "Total Listings: #{Listing.all.count}"
+    # puts "Discriminatory: #{Listing.where(discriminatory: true).count}"
+    # breakdown = Listing.left_outer_joins(:phrases).where(listed_at: '2010-01-01'...'2020-01-01').group(:content).count
+    # puts breakdown
+    # puts breakdown.values.reduce(:+)
+    #
+    # i = 0
+    # Listing.where(discriminatory: true).each do |listing|
+    #   puts listing.phrases.count
+    #   listing.phrases.each do |phrase|
+    #     # i += 1
+    #     # puts i
+    #     # puts phrase.content
+    #   end
+    # end
+
+  end
+
+
+
+
 end


### PR DESCRIPTION
I noticed that the stats for the discriminatory phrase count were being parsed/calculated from the actual listing descriptions each time a query was run from /tools/stats. The discriminatory phrase count variable was being set by calling listing.check_phrase for each phrase rather than relying on the established discriminatory phrase_listings table. This seems redundant to me, is slow, and does not produce the same results as a join between the listings and phrases table (through phrase_listings).  I believe the correct approach is to rely on data in the existing table, otherwise I'm not sure what the function of the phrase_listings table is.

I may be a bit confused, but it also appears that bin/rake classify_listings:initial_set sets discriminatory:true if listing.illegal? is true..but listing.illegal only returns true if listing.discriminatory
is true. It doesn't appear to actually classify listings as discriminatory?




